### PR TITLE
Support for Red vs. Blue Alliance

### DIFF
--- a/code/GeneralSupportFunctions.py
+++ b/code/GeneralSupportFunctions.py
@@ -1,4 +1,4 @@
-# Date: 2023-01-08
+# Date: 2023-01-15
 # Description: general support functions
 #-----------------------------------------------------------------------------
 
@@ -9,6 +9,7 @@ from matplotlib.patches import Patch # graphics object
 import numpy as np # Numpy toolbox
 import os # access to Windows OS
 from PIL import ImageTk,Image # TkInter-integrated image display functionality 
+import shutil # used for copying files
 import tkinter as tk # TkInter UI backbone
 
 # Hardcoded directory paths
@@ -45,8 +46,8 @@ def copySelectedFile(path,moveto):
         None
     """
     
-    # Construct the required Windows command string 
-    os.system('copy "'+path.replace('\\','\\').replace('/','\\')+'" "'+moveto.replace('\\','\\').replace('/','\\')+'"')
+    try: shutil.copyfile(path.replace('/','\\'),moveto.replace('/','\\'))
+    except shutil.SameFileError as e: print(e)
     
     # Report the copied file
     print(path)

--- a/code/Main.py
+++ b/code/Main.py
@@ -1,4 +1,4 @@
-# Date: 2023-01-08
+# Date: 2023-01-22
 # Description: a path planner for the FIRST Robotics Competition
 #-----------------------------------------------------------------------------
 
@@ -555,6 +555,10 @@ def actionLoadField(*args):
     # Reinitialize the path
     path.reset()
     
+    # Ask the user which alliance they are planning for
+    if(tk.messagebox.askyesno(softwareName,'Are you planning a path for the RED alliance?')): alliance = 'red'
+    else: alliance = 'blue'
+    
     # Ask the user to load a field map
     try: file_I = str(np.load(dirPvars+'rememberedField.npy'))
     except: file_I = filedialog.askopenfilename(initialdir='../field drawings/',title = 'Select a Field Drawing',filetypes=recognizedImageExtensions)
@@ -568,21 +572,25 @@ def actionLoadField(*args):
         if(file_robot!=''): np.save(dirPvars+'rememberedRobot.npy',file_robot)
         
         # Ask the user to load calibration points for the red side of the field
-        try: file_red = str(np.load(dirPvars+'rememberedRedPoints.npy'))
-        except: file_red = filedialog.askopenfilename(title = 'Select Field Calibration Points for the Red Side',filetypes=[('CSV','*.csv ')])
-        if(file_red!=''): np.save(dirPvars+'rememberedRedPoints.npy',file_red)
+        if(alliance=='red'):
+            try: file_red = str(np.load(dirPvars+'rememberedRedPoints.npy'))
+            except: file_red = filedialog.askopenfilename(title = 'Select Field Calibration Points for the Red Side',filetypes=[('CSV','*.csv ')])
+            if(file_red!=''): np.save(dirPvars+'rememberedRedPoints.npy',file_red)
+        else: file_red = ''
         
         # Ask the user to load calibration points for the blue side of the field
-        try: file_blue = str(np.load(dirPvars+'rememberedBluePoints.npy'))
-        except: file_blue = filedialog.askopenfilename(title = 'Select Field Calibration Points for the Blue Side',filetypes=[('CSV','*.csv ')])
-        if(file_blue!=''): np.save(dirPvars+'rememberedBluePoints.npy',file_blue)
+        if(alliance=='blue'):
+            try: file_blue = str(np.load(dirPvars+'rememberedBluePoints.npy'))
+            except: file_blue = filedialog.askopenfilename(title = 'Select Field Calibration Points for the Blue Side',filetypes=[('CSV','*.csv ')])
+            if(file_blue!=''): np.save(dirPvars+'rememberedBluePoints.npy',file_blue)
+        else: file_blue = ''
         
         # Ask the user to load a previous path
         file_csv = filedialog.askopenfilename(initialdir='',title = 'Select a Robot Path',filetypes=[('CSV','*.csv ')])
         path.loadWayPoints(file_csv)
         
         # Start the path planner
-        try: plan.definePath(path,file_I,file_robot,buttonPlan,file_red,file_blue)
+        try: plan.definePath(path,alliance,file_I,file_robot,buttonPlan,file_red,file_blue)
         except: buttonPlan.configure(bg=guiColor_hotgreen,state=tk.NORMAL)
         
     else: buttonPlan.configure(bg=guiColor_hotgreen,state=tk.NORMAL)

--- a/code/Main.py
+++ b/code/Main.py
@@ -3,8 +3,8 @@
 #-----------------------------------------------------------------------------
 
 # Versioning information
-versionNumber = '2.3.0' # breaking.major-feature-add.minor-feature-or-bug-fix
-versionType = 'stable' # options are "dev" or "stable"
+versionNumber = '2.3.1' # breaking.major-feature-add.minor-feature-or-bug-fix
+versionType = 'dev' # options are "dev" or "stable"
 print('Loading v%s...' %(versionNumber))
 
 # Ignore future and depreciation warnings when not in development

--- a/code/Main.py
+++ b/code/Main.py
@@ -4,7 +4,7 @@
 
 # Versioning information
 versionNumber = '2.3.1' # breaking.major-feature-add.minor-feature-or-bug-fix
-versionType = 'dev' # options are "dev" or "stable"
+versionType = 'stable' # options are "dev" or "stable"
 print('Loading v%s...' %(versionNumber))
 
 # Ignore future and depreciation warnings when not in development

--- a/code/PathPlanning.py
+++ b/code/PathPlanning.py
@@ -408,14 +408,18 @@ def popupPtData(path,x_prior,y_prior,flag_newPt):
         # Check entries for errors
         flags = True
         [O_way,flags] = gensup.safeTextEntry(flags,textFields[0]['field'],'int',vmin=0,vmax=path.numWayPoints())
-        [x_way,flags] = gensup.safeTextEntry(flags,textFields[1]['field'],'float',vmin=0.0,vmax=path.field_x_real)
-        [y_way,flags] = gensup.safeTextEntry(flags,textFields[2]['field'],'float',vmin=0.0,vmax=path.field_y_real)
+        [x_way,flags] = gensup.safeTextEntry(flags,textFields[1]['field'],'float',vmin=-path.field_x_real,vmax=path.field_x_real)
+        [y_way,flags] = gensup.safeTextEntry(flags,textFields[2]['field'],'float',vmin=-path.field_y_real,vmax=path.field_y_real)
         [v_way,flags] = gensup.safeTextEntry(flags,textFields[3]['field'],'float',vmin=path.v_min/12.0,vmax=path.v_max/12.0)
         [o_way,flags] = gensup.safeTextEntry(flags,textFields[4]['field'],'float',vmin=0.0,vmax=360.0)
         [R_way,flags] = gensup.safeTextEntry(flags,textFields[5]['field'],'float',vmin=3*path.step_size)
         [T_way,flags] = gensup.safeTextEntry(flags,textFields[6]['field'],'bool')
         if(T_way): T_way = 1
         else: T_way = 0
+        
+        # Perform any requested waypoint flips ***
+        if(x_way<0): x_way += path.field_x_real
+        if(y_way<0): y_way += path.field_y_real
     
         # Save the error-free entries in the correct units
         if(flags):
@@ -622,7 +626,7 @@ def definePath(path_loaded,alliance,file_I,file_robot,buttonPlan,file_red,file_b
     I = cv2.imread(file_I,cv2.IMREAD_COLOR) # load the selected image 
     I = cv2.resize(I,(int(dispRes*path.field_x_real),int(dispRes*path.field_y_real))) # resize the image
     I = gensup.convertColorSpace(I) # fix image coloring
-    if(alliance=='blue'): I = cv2.rotate(I,cv2.ROTATE_180) # rotate the field image ***
+    if(alliance=='blue'): I = cv2.rotate(I,cv2.ROTATE_180) # rotate the field image
     
     # Calculate the scaling 
     path.fieldScale(I)

--- a/code/VersioningControl.py
+++ b/code/VersioningControl.py
@@ -198,6 +198,9 @@ Release Notes
 -------------------------------------------------------------------------------------
 
 v***
+> Changes the path velocity color map.
+> Robot and waypoint colors will adjust automatically based on the alliance selection.
+> The user can now specify which alliance they are planning a path for so that the field is flipped the correct direction.
 > The installer will no longer fail if the desktop shortcut can't be created.
 > Updates the file copying backend from os to shutil to fix issues with different user accounts unpacked resource files.
 

--- a/code/VersioningControl.py
+++ b/code/VersioningControl.py
@@ -185,6 +185,8 @@ The "4265 Path Planner" an autonomous path planner for the FIRST Robotics Compet
 Release Notes
 -------------------------------------------------------------------------------------
 
+v***
+
 v2.3.0
 > Fixes a bug with the custom toolbar icons.
 > Allows the path planner version to be updated by just double-clicking a new executable.

--- a/code/VersioningControl.py
+++ b/code/VersioningControl.py
@@ -1,4 +1,4 @@
-# Date: 2023-01-08
+# Date: 2023-01-15
 # Description: auto-generates the readme.txt file and handle software upgrades
 # and installation
 #-----------------------------------------------------------------------------
@@ -26,6 +26,16 @@ def resourcePath(relative_path):
     except: base_path = os.path.abspath(".")
     
     return os.path.join(base_path,relative_path)
+
+#-----------------------------------------------------------------------------
+
+def unpackResource(filename):
+    """
+    Unpacks the specified resource file to the vars/ directory
+    """
+    
+    try: shutil.copyfile(resourcePath(filename),dirPvars+filename)
+    except: pass
 
 #-----------------------------------------------------------------------------
 
@@ -89,18 +99,20 @@ def install(argv):
         # Ask the user if they would like to create a desktop shortcut
         create_shortcut = messagebox.askyesno('4265 Path Planner','Would you like to create a desktop shortcut?')
         if(create_shortcut):
-            print('Creating a desktop shortcut...')
-            desktop = os.path.expanduser('~/Desktop')
-            path = os.path.join(desktop,'FRC 4265 Path Planner.lnk')
-            target = os.path.join(os.getcwd(),'FRC 4265 Path Planner.exe')
-            wDir = os.getcwd()
-            icon = os.path.join(os.getcwd(),'FRC 4265 Path Planner.exe')
-            shell = Dispatch('WScript.Shell')
-            shortcut = shell.CreateShortCut(path)
-            shortcut.Targetpath = target
-            shortcut.WorkingDirectory = wDir
-            shortcut.IconLocation = icon
-            shortcut.save()
+            try:
+                print('Creating a desktop shortcut...')
+                desktop = os.path.expanduser('~/Desktop')
+                path = os.path.join(desktop,'FRC 4265 Path Planner.lnk')
+                target = os.path.join(os.getcwd(),'FRC 4265 Path Planner.exe')
+                wDir = os.getcwd()
+                icon = os.path.join(os.getcwd(),'FRC 4265 Path Planner.exe')
+                shell = Dispatch('WScript.Shell')
+                shortcut = shell.CreateShortCut(path)
+                shortcut.Targetpath = target
+                shortcut.WorkingDirectory = wDir
+                shortcut.IconLocation = icon
+                shortcut.save()
+            except: print('Error: Could not create the desktop shortcut.')
             
         # Save the Operating System information
         np.save(dirPvars+'ostype.npy','Windows')
@@ -128,12 +140,12 @@ def upgrade(versionNumber_current):
         print('Finalizing upgrade from v%s to v%s...' %(versionNumber_old,versionNumber_current))
         
         # Move supporting files to the correct folders
-        os.system('move '+resourcePath('graphic_4265.png')+' "'+'../vars'+'"')
-        os.system('move '+resourcePath('addwaypoint.png')+' "'+'../vars'+'"')
-        os.system('move '+resourcePath('editwaypoint.png')+' "'+'../vars'+'"')
-        os.system('move '+resourcePath('savepath.png')+' "'+'../vars'+'"')
-        os.system('move '+resourcePath('probe.png')+' "'+'../vars'+'"')
-        os.system('move '+resourcePath('movewaypoint.png')+' "'+'../vars'+'"')
+        unpackResource('graphic_4265.png')
+        unpackResource('addwaypoint.png')
+        unpackResource('editwaypoint.png')
+        unpackResource('savepath.png')
+        unpackResource('probe.png')
+        unpackResource('movewaypoint.png')
         
         # Delete the old readme file
         try: os.remove(dirPvars+'readme.txt')
@@ -186,6 +198,8 @@ Release Notes
 -------------------------------------------------------------------------------------
 
 v***
+> The installer will no longer fail if the desktop shortcut can't be created.
+> Updates the file copying backend from os to shutil to fix issues with different user accounts unpacked resource files.
 
 v2.3.0
 > Fixes a bug with the custom toolbar icons.

--- a/code/VersioningControl.py
+++ b/code/VersioningControl.py
@@ -197,7 +197,8 @@ The "4265 Path Planner" an autonomous path planner for the FIRST Robotics Compet
 Release Notes
 -------------------------------------------------------------------------------------
 
-v***
+v2.3.1
+> Waypoints can now be flipped about the x or y axes by enditing a waypoint and placing a negative sign in front of the desired coordinate.
 > Changes the path velocity color map.
 > Robot and waypoint colors will adjust automatically based on the alliance selection.
 > The user can now specify which alliance they are planning a path for so that the field is flipped the correct direction.

--- a/freezing/cache/GeneralSupportFunctions.py
+++ b/freezing/cache/GeneralSupportFunctions.py
@@ -1,4 +1,4 @@
-# Date: 2023-01-08
+# Date: 2023-01-15
 # Description: general support functions
 #-----------------------------------------------------------------------------
 
@@ -9,6 +9,7 @@ from matplotlib.patches import Patch # graphics object
 import numpy as np # Numpy toolbox
 import os # access to Windows OS
 from PIL import ImageTk,Image # TkInter-integrated image display functionality 
+import shutil # used for copying files
 import tkinter as tk # TkInter UI backbone
 
 # Hardcoded directory paths
@@ -45,8 +46,8 @@ def copySelectedFile(path,moveto):
         None
     """
     
-    # Construct the required Windows command string 
-    os.system('copy "'+path.replace('\\','\\').replace('/','\\')+'" "'+moveto.replace('\\','\\').replace('/','\\')+'"')
+    try: shutil.copyfile(path.replace('/','\\'),moveto.replace('/','\\'))
+    except shutil.SameFileError as e: print(e)
     
     # Report the copied file
     print(path)

--- a/freezing/cache/Main.py
+++ b/freezing/cache/Main.py
@@ -3,7 +3,7 @@
 #-----------------------------------------------------------------------------
 
 # Versioning information
-versionNumber = '2.3.0' # breaking.major-feature-add.minor-feature-or-bug-fix
+versionNumber = '2.3.1' # breaking.major-feature-add.minor-feature-or-bug-fix
 versionType = 'stable' # options are "dev" or "stable"
 print('Loading v%s...' %(versionNumber))
 

--- a/freezing/cache/Main.py
+++ b/freezing/cache/Main.py
@@ -1,4 +1,4 @@
-# Date: 2023-01-08
+# Date: 2023-01-22
 # Description: a path planner for the FIRST Robotics Competition
 #-----------------------------------------------------------------------------
 
@@ -555,6 +555,10 @@ def actionLoadField(*args):
     # Reinitialize the path
     path.reset()
     
+    # Ask the user which alliance they are planning for
+    if(tk.messagebox.askyesno(softwareName,'Are you planning a path for the RED alliance?')): alliance = 'red'
+    else: alliance = 'blue'
+    
     # Ask the user to load a field map
     try: file_I = str(np.load(dirPvars+'rememberedField.npy'))
     except: file_I = filedialog.askopenfilename(initialdir='../field drawings/',title = 'Select a Field Drawing',filetypes=recognizedImageExtensions)
@@ -568,21 +572,25 @@ def actionLoadField(*args):
         if(file_robot!=''): np.save(dirPvars+'rememberedRobot.npy',file_robot)
         
         # Ask the user to load calibration points for the red side of the field
-        try: file_red = str(np.load(dirPvars+'rememberedRedPoints.npy'))
-        except: file_red = filedialog.askopenfilename(title = 'Select Field Calibration Points for the Red Side',filetypes=[('CSV','*.csv ')])
-        if(file_red!=''): np.save(dirPvars+'rememberedRedPoints.npy',file_red)
+        if(alliance=='red'):
+            try: file_red = str(np.load(dirPvars+'rememberedRedPoints.npy'))
+            except: file_red = filedialog.askopenfilename(title = 'Select Field Calibration Points for the Red Side',filetypes=[('CSV','*.csv ')])
+            if(file_red!=''): np.save(dirPvars+'rememberedRedPoints.npy',file_red)
+        else: file_red = ''
         
         # Ask the user to load calibration points for the blue side of the field
-        try: file_blue = str(np.load(dirPvars+'rememberedBluePoints.npy'))
-        except: file_blue = filedialog.askopenfilename(title = 'Select Field Calibration Points for the Blue Side',filetypes=[('CSV','*.csv ')])
-        if(file_blue!=''): np.save(dirPvars+'rememberedBluePoints.npy',file_blue)
+        if(alliance=='blue'):
+            try: file_blue = str(np.load(dirPvars+'rememberedBluePoints.npy'))
+            except: file_blue = filedialog.askopenfilename(title = 'Select Field Calibration Points for the Blue Side',filetypes=[('CSV','*.csv ')])
+            if(file_blue!=''): np.save(dirPvars+'rememberedBluePoints.npy',file_blue)
+        else: file_blue = ''
         
         # Ask the user to load a previous path
         file_csv = filedialog.askopenfilename(initialdir='',title = 'Select a Robot Path',filetypes=[('CSV','*.csv ')])
         path.loadWayPoints(file_csv)
         
         # Start the path planner
-        try: plan.definePath(path,file_I,file_robot,buttonPlan,file_red,file_blue)
+        try: plan.definePath(path,alliance,file_I,file_robot,buttonPlan,file_red,file_blue)
         except: buttonPlan.configure(bg=guiColor_hotgreen,state=tk.NORMAL)
         
     else: buttonPlan.configure(bg=guiColor_hotgreen,state=tk.NORMAL)

--- a/freezing/cache/VersioningControl.py
+++ b/freezing/cache/VersioningControl.py
@@ -1,4 +1,4 @@
-# Date: 2023-01-08
+# Date: 2023-01-15
 # Description: auto-generates the readme.txt file and handle software upgrades
 # and installation
 #-----------------------------------------------------------------------------
@@ -26,6 +26,16 @@ def resourcePath(relative_path):
     except: base_path = os.path.abspath(".")
     
     return os.path.join(base_path,relative_path)
+
+#-----------------------------------------------------------------------------
+
+def unpackResource(filename):
+    """
+    Unpacks the specified resource file to the vars/ directory
+    """
+    
+    try: shutil.copyfile(resourcePath(filename),dirPvars+filename)
+    except: pass
 
 #-----------------------------------------------------------------------------
 
@@ -89,18 +99,20 @@ def install(argv):
         # Ask the user if they would like to create a desktop shortcut
         create_shortcut = messagebox.askyesno('4265 Path Planner','Would you like to create a desktop shortcut?')
         if(create_shortcut):
-            print('Creating a desktop shortcut...')
-            desktop = os.path.expanduser('~/Desktop')
-            path = os.path.join(desktop,'FRC 4265 Path Planner.lnk')
-            target = os.path.join(os.getcwd(),'FRC 4265 Path Planner.exe')
-            wDir = os.getcwd()
-            icon = os.path.join(os.getcwd(),'FRC 4265 Path Planner.exe')
-            shell = Dispatch('WScript.Shell')
-            shortcut = shell.CreateShortCut(path)
-            shortcut.Targetpath = target
-            shortcut.WorkingDirectory = wDir
-            shortcut.IconLocation = icon
-            shortcut.save()
+            try:
+                print('Creating a desktop shortcut...')
+                desktop = os.path.expanduser('~/Desktop')
+                path = os.path.join(desktop,'FRC 4265 Path Planner.lnk')
+                target = os.path.join(os.getcwd(),'FRC 4265 Path Planner.exe')
+                wDir = os.getcwd()
+                icon = os.path.join(os.getcwd(),'FRC 4265 Path Planner.exe')
+                shell = Dispatch('WScript.Shell')
+                shortcut = shell.CreateShortCut(path)
+                shortcut.Targetpath = target
+                shortcut.WorkingDirectory = wDir
+                shortcut.IconLocation = icon
+                shortcut.save()
+            except: print('Error: Could not create the desktop shortcut.')
             
         # Save the Operating System information
         np.save(dirPvars+'ostype.npy','Windows')
@@ -128,12 +140,12 @@ def upgrade(versionNumber_current):
         print('Finalizing upgrade from v%s to v%s...' %(versionNumber_old,versionNumber_current))
         
         # Move supporting files to the correct folders
-        os.system('move '+resourcePath('graphic_4265.png')+' "'+'../vars'+'"')
-        os.system('move '+resourcePath('addwaypoint.png')+' "'+'../vars'+'"')
-        os.system('move '+resourcePath('editwaypoint.png')+' "'+'../vars'+'"')
-        os.system('move '+resourcePath('savepath.png')+' "'+'../vars'+'"')
-        os.system('move '+resourcePath('probe.png')+' "'+'../vars'+'"')
-        os.system('move '+resourcePath('movewaypoint.png')+' "'+'../vars'+'"')
+        unpackResource('graphic_4265.png')
+        unpackResource('addwaypoint.png')
+        unpackResource('editwaypoint.png')
+        unpackResource('savepath.png')
+        unpackResource('probe.png')
+        unpackResource('movewaypoint.png')
         
         # Delete the old readme file
         try: os.remove(dirPvars+'readme.txt')
@@ -184,6 +196,10 @@ The "4265 Path Planner" an autonomous path planner for the FIRST Robotics Compet
 -------------------------------------------------------------------------------------
 Release Notes
 -------------------------------------------------------------------------------------
+
+v2.3.1
+> The installer will no longer fail if the desktop shortcut can't be created.
+> Updates the file copying backend from os to shutil to fix issues with different user accounts unpacked resource files.
 
 v2.3.0
 > Fixes a bug with the custom toolbar icons.

--- a/freezing/cache/VersioningControl.py
+++ b/freezing/cache/VersioningControl.py
@@ -198,6 +198,10 @@ Release Notes
 -------------------------------------------------------------------------------------
 
 v2.3.1
+> Waypoints can now be flipped about the x or y axes by enditing a waypoint and placing a negative sign in front of the desired coordinate.
+> Changes the path velocity color map.
+> Robot and waypoint colors will adjust automatically based on the alliance selection.
+> The user can now specify which alliance they are planning a path for so that the field is flipped the correct direction.
 > The installer will no longer fail if the desktop shortcut can't be created.
 > Updates the file copying backend from os to shutil to fix issues with different user accounts unpacked resource files.
 


### PR DESCRIPTION
```
v2.3.1
> Waypoints can now be flipped about the x or y axes by enditing a waypoint and placing a negative sign in front of the desired coordinate.
> Changes the path velocity color map.
> Robot and waypoint colors will adjust automatically based on the alliance selection.
> The user can now specify which alliance they are planning a path for so that the field is flipped the correct direction.
> The installer will no longer fail if the desktop shortcut can't be created.
> Updates the file copying backend from os to shutil to fix issues with different user accounts unpacked resource files.
```